### PR TITLE
Added new setup option 'Require WiFi'

### DIFF
--- a/app/src/main/java/com/example/trigger/HttpsDoorSetup.java
+++ b/app/src/main/java/com/example/trigger/HttpsDoorSetup.java
@@ -12,6 +12,7 @@ public class HttpsDoorSetup implements Setup {
     static final String type = "HttpsDoorSetup";
     int id;
     String name;
+    public Boolean require_wifi;
     public String method;
     public String open_query;
     public String close_query;
@@ -30,6 +31,7 @@ public class HttpsDoorSetup implements Setup {
     public HttpsDoorSetup(int id, String name) {
         this.id = id;
         this.name = name;
+        this.require_wifi = true;
         this.method = "";
         this.open_query = "";
         this.close_query = "";

--- a/app/src/main/java/com/example/trigger/MqttDoorSetup.java
+++ b/app/src/main/java/com/example/trigger/MqttDoorSetup.java
@@ -11,6 +11,7 @@ public class MqttDoorSetup implements Setup {
     static final String type = "MqttDoorSetup";
     int id;
     String name;
+    public Boolean require_wifi;
     public String username;
     public String password;
     public String server;
@@ -33,6 +34,7 @@ public class MqttDoorSetup implements Setup {
     public MqttDoorSetup(int id, String name) {
         this.id = id;
         this.name = name;
+        this.require_wifi = true;
         this.username = "";
         this.password = "";
         this.server = "";

--- a/app/src/main/java/com/example/trigger/SshDoorSetup.java
+++ b/app/src/main/java/com/example/trigger/SshDoorSetup.java
@@ -11,6 +11,7 @@ public class SshDoorSetup implements Setup {
     static final String type = "SshDoorSetup";
     int id;
     String name;
+    public Boolean require_wifi;
     public KeyPair keypair;
     public String user;
     public String password;
@@ -30,6 +31,7 @@ public class SshDoorSetup implements Setup {
     public SshDoorSetup(int id, String name) {
         this.id = id;
         this.name = name;
+        this.require_wifi = true;
         this.keypair = null;
         this.user = "";
         this.password = "";

--- a/app/src/main/java/com/example/trigger/https/HttpsRequestHandler.java
+++ b/app/src/main/java/com/example/trigger/https/HttpsRequestHandler.java
@@ -34,7 +34,7 @@ public class HttpsRequestHandler extends Thread {
             return;
         }
 
-        if (!WifiTools.isConnected()) {
+        if (setup.require_wifi && !WifiTools.isConnected()) {
             this.listener.onTaskResult(setup.getId(), ReplyCode.DISABLED, "Wifi Disabled.");
             return;
         }

--- a/app/src/main/java/com/example/trigger/mqtt/MqttRequestHandler.java
+++ b/app/src/main/java/com/example/trigger/mqtt/MqttRequestHandler.java
@@ -37,7 +37,7 @@ public class MqttRequestHandler extends Thread implements MqttCallback {
             return;
         }
 
-        if (!WifiTools.isConnected()) {
+        if (setup.require_wifi && !WifiTools.isConnected()) {
             this.listener.onTaskResult(setup.getId(), ReplyCode.DISABLED, "Wifi Disabled.");
             return;
         }

--- a/app/src/main/java/com/example/trigger/ssh/SshRequestHandler.java
+++ b/app/src/main/java/com/example/trigger/ssh/SshRequestHandler.java
@@ -35,7 +35,7 @@ public class SshRequestHandler extends Thread {
             return;
         }
 
-        if (!WifiTools.isConnected()) {
+        if (setup.require_wifi && !WifiTools.isConnected()) {
             this.listener.onTaskResult(setup.getId(), ReplyCode.DISABLED, "Wifi Disabled.");
             return;
         }

--- a/app/src/main/res/xml/setup.xml
+++ b/app/src/main/res/xml/setup.xml
@@ -27,6 +27,12 @@
         android:persistent="false"
         android:title="HTTPS Settings">
 
+        <CheckBoxPreference
+            android:key="require_wifi"
+            android:title="Require WiFi"
+            android:defaultValue="true"
+            android:persistent="false" />
+
         <com.example.trigger.https.CertificatePreference
             android:key="certificate"
             android:title="Certificate"
@@ -106,6 +112,12 @@
             android:title="SSH Settings"
             android:key="SshDoorSetup"
             android:persistent="false" >
+
+        <CheckBoxPreference
+            android:key="require_wifi"
+            android:title="Require WiFi"
+            android:defaultValue="true"
+            android:persistent="false" />
 
         <com.example.trigger.ssh.KeyPairPreference
             android:key="keypair"
@@ -329,6 +341,12 @@
             android:key="MqttDoorSetup"
             android:title="MQTT Settings"
             android:persistent="false" >
+
+        <CheckBoxPreference
+            android:key="require_wifi"
+            android:title="Require WiFi"
+            android:defaultValue="true"
+            android:persistent="false" />
 
         <EditTextPreference
             android:key="server"


### PR DESCRIPTION
This will allow you to unlock doors over the internet as well as the local network.
For door types HTTPS, SSH, MQTT a new checkbox option 'Require WiFi' is added.

Unchecking this option, will disable the 'Wifi Disbled' message which prevents unlocking doors over the internet.