### PR TITLE
Add support for basic auth from the URL.

### DIFF
--- a/app/src/main/java/app/trigger/https/HttpsRequestHandler.java
+++ b/app/src/main/java/app/trigger/https/HttpsRequestHandler.java
@@ -20,6 +20,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
+import android.util.Base64;
+
 import app.trigger.MainActivity.Action;
 import app.trigger.HttpsDoorSetup;
 import app.trigger.DoorReply.ReplyCode;
@@ -103,6 +105,11 @@ public class HttpsRequestHandler extends Thread {
         try {
             URL url = new URL(command);
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
+
+            if (url.getUserInfo() != null) {
+                String basicAuth = "Basic " + Base64.encodeToString(url.getUserInfo().getBytes(), Base64.DEFAULT);
+                con.setRequestProperty("Authorization", basicAuth);
+            }
 
             if (con instanceof HttpsURLConnection) {
                 HttpsURLConnection https = (HttpsURLConnection) con;


### PR DESCRIPTION
That is, a URL such as https://user:password@example.com/open_door will now
send user as the basic authentication username, and password as the password.

This has been tested, at least on my device in my environment.