### PR TITLE
Added possibility to connect to a MQTT server with a client certificate

### DIFF
--- a/app/src/main/java/app/trigger/MqttDoorSetup.java
+++ b/app/src/main/java/app/trigger/MqttDoorSetup.java
@@ -3,8 +3,10 @@ package app.trigger;
 import android.graphics.Bitmap;
 
 import app.trigger.DoorState.StateCode;
+import app.trigger.ssh.KeyPairBean;
 
 import java.security.cert.Certificate;
+import java.security.PrivateKey;
 
 
 public class MqttDoorSetup implements Setup {
@@ -34,6 +36,8 @@ public class MqttDoorSetup implements Setup {
 
     public String ssids;
     public Certificate certificate;
+    public Certificate client_certificate;
+    public KeyPairBean client_key;
 
     public MqttDoorSetup(int id, String name) {
         this.id = id;

--- a/app/src/main/java/app/trigger/mqtt/MqttRequestHandler.java
+++ b/app/src/main/java/app/trigger/mqtt/MqttRequestHandler.java
@@ -112,7 +112,7 @@ public class MqttRequestHandler extends Thread implements MqttCallback {
                 if (setup.certificate != null) {
                     // use given certificate only
                     if(setup.client_certificate != null && setup.client_key != null) {
-                        PrivateKey client_private_key = PubkeyUtils.decodePrivate(setup.client_key.getPrivateKey(),"RSA");
+                        PrivateKey client_private_key = PubkeyUtils.decodePrivate(setup.client_key.getPrivateKey(),setup.client_key.getType());
                         opts.setSocketFactory(
                                 Utils.getSocketFactoryWithCertificateAndClientKey(setup.certificate,setup.client_certificate,client_private_key)
                         );

--- a/app/src/main/java/app/trigger/mqtt/MqttRequestHandler.java
+++ b/app/src/main/java/app/trigger/mqtt/MqttRequestHandler.java
@@ -10,6 +10,9 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
 import app.trigger.Utils;
 import app.trigger.MainActivity.Action;
 import app.trigger.MqttDoorSetup;
@@ -18,6 +21,7 @@ import app.trigger.DoorReply.ReplyCode;
 import app.trigger.OnTaskCompleted;
 import app.trigger.Log;
 import app.trigger.WifiTools;
+import app.trigger.ssh.PubkeyUtils;
 
 
 public class MqttRequestHandler extends Thread implements MqttCallback {
@@ -107,9 +111,17 @@ public class MqttRequestHandler extends Thread implements MqttCallback {
             if (address.startsWith("ssl://")) {
                 if (setup.certificate != null) {
                     // use given certificate only
-                    opts.setSocketFactory(
-                            Utils.getSocketFactoryWithCertificate(setup.certificate)
-                    );
+                    if(setup.client_certificate != null && setup.client_key != null) {
+                        PrivateKey client_private_key = PubkeyUtils.decodePrivate(setup.client_key.getPrivateKey(),"RSA");
+                        opts.setSocketFactory(
+                                Utils.getSocketFactoryWithCertificateAndClientKey(setup.certificate,setup.client_certificate,client_private_key)
+                        );
+                    }
+                    else {
+                        opts.setSocketFactory(
+                                Utils.getSocketFactoryWithCertificate(setup.certificate)
+                        );
+                    }
                 } else {
                     // use system default certificates
                     opts.setSocketFactory(

--- a/app/src/main/java/app/trigger/ssh/KeyPairBean.java
+++ b/app/src/main/java/app/trigger/ssh/KeyPairBean.java
@@ -33,7 +33,7 @@ public class KeyPairBean implements Serializable {
     public boolean encrypted = false;
     public String nickname = "";
 
-    String getType() {
+    public String getType() {
         return type;
     }
 

--- a/app/src/main/java/app/trigger/ssh/KeyPairBean.java
+++ b/app/src/main/java/app/trigger/ssh/KeyPairBean.java
@@ -41,7 +41,7 @@ public class KeyPairBean implements Serializable {
         return publicKey;
     }
 
-    byte[] getPrivateKey() {
+    public byte[] getPrivateKey() {
         return privateKey;
     }
 

--- a/app/src/main/res/xml/setup.xml
+++ b/app/src/main/res/xml/setup.xml
@@ -472,6 +472,18 @@
             android:persistent="false"
             android:defaultValue="false" />
 
+        <app.trigger.https.CertificatePreference
+            android:key="client_certificate"
+            android:title="Client Certificate"
+            android:persistent="false"
+            android:defaultValue="false" />
+
+        <app.trigger.ssh.KeyPairPreference
+            android:key="client_key"
+            android:title="Client Private Key"
+            android:persistent="false"
+            android:defaultValue="false" />
+
         <EditTextPreference
             android:key="locked_pattern"
             android:title="Reply Pattern (locked)"


### PR DESCRIPTION
I have added the possibility to specify a client key and certificate, which can be uses to connect to a MQTT Server. This connection is only attempted if both key and certificate are supplied. Right now this are two separate input parameters in the config.  The old option where just a server CA certificate was supplied still works. 